### PR TITLE
Remove open keyword

### DIFF
--- a/features/characters_list/src/main/kotlin/com/vmadalin/dynamicfeatures/characterslist/ui/list/model/CharacterItemMapper.kt
+++ b/features/characters_list/src/main/kotlin/com/vmadalin/dynamicfeatures/characterslist/ui/list/model/CharacterItemMapper.kt
@@ -27,7 +27,7 @@ private const val IMAGE_URL_FORMAT = "%s.%s"
  *
  * @see Mapper
  */
-open class CharacterItemMapper : Mapper<BaseResponse<CharacterResponse>, List<CharacterItem>> {
+class CharacterItemMapper : Mapper<BaseResponse<CharacterResponse>, List<CharacterItem>> {
 
     /**
      * Transform network response to [CharacterItem].


### PR DESCRIPTION
## Description

Removed open keyword on CharacterItemMapper class. It is not inherited  by any class.

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have commented my code, particularly in hard-to-understand areas
-   [ ] I have made corresponding changes to the documentation
-   [x] My changes generate no new warnings
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
-   [ ] Any dependent changes have been merged and published in downstream modules
